### PR TITLE
fix: CMAKE_INSTALL_LIBDIR

### DIFF
--- a/faiss-sys/build.rs
+++ b/faiss-sys/build.rs
@@ -18,6 +18,7 @@ fn static_link_faiss() {
         })
         .define("FAISS_ENABLE_PYTHON", "OFF")
         .define("BUILD_TESTING", "OFF")
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
         .very_verbose(true);
     let dst = cfg.build();
     let faiss_location = dst.join("lib");


### PR DESCRIPTION
↓ここで、DESTINATION が CMAKE_INSTALL_LIBDIR を参照している
https://github.com/facebookresearch/faiss/blob/main/faiss/CMakeLists.txt#L293

CMAKE_INSTALL_LIBDIR が OS ごとに `lib` になったり `lib64` になるので、cmake の config 時に `lib` に固定しておく